### PR TITLE
feat: Improved/Corrected Types

### DIFF
--- a/pgtransaction/transaction.py
+++ b/pgtransaction/transaction.py
@@ -86,7 +86,7 @@ class Atomic(transaction.Atomic):
 
                 num_retries += 1
 
-        return inner  # type: ignore - we only care about accuracy for the outer function
+        return inner  # type: ignore - we only care about accuracy for the outer method
 
     def execute_set_isolation_level(self) -> None:
         with self.connection.cursor() as cursor:

--- a/pgtransaction/transaction.py
+++ b/pgtransaction/transaction.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import cached_property, wraps
-from typing import Any, Callable, Final, TypeVar, overload
+from typing import Any, Callable, Final, Literal, TypeVar, overload
 
 import django
 from django.db import DEFAULT_DB_ALIAS, Error, transaction
@@ -22,7 +22,7 @@ class Atomic(transaction.Atomic):
         using: str | None,
         savepoint: bool,
         durable: bool,
-        isolation_level: str | None,
+        isolation_level: Literal["READ COMMITTED", "REPEATABLE READ", "SERIALIZABLE"] | None,
         retry: int | None,
     ):
         if django.VERSION >= (3, 2):
@@ -128,7 +128,7 @@ def atomic(
     using: str | None = None,
     savepoint: bool = True,
     durable: bool = False,
-    isolation_level: str | None = None,
+    isolation_level: Literal["READ COMMITTED", "REPEATABLE READ", "SERIALIZABLE"] | None = None,
     retry: int | None = None,
 ) -> Atomic: ...
 
@@ -137,7 +137,7 @@ def atomic(
     using: str | None | _C = None,
     savepoint: bool = True,
     durable: bool = False,
-    isolation_level: str | None = None,
+    isolation_level: Literal["READ COMMITTED", "REPEATABLE READ", "SERIALIZABLE"] | None = None,
     retry: int | None = None,
 ) -> Atomic | _C:
     """


### PR DESCRIPTION
Add missing types, and add overloads for `atomic` similar to the `transaction.atomic` stubs in django-stubs:

```python
@overload
def atomic(using: _C) -> _C: ...

# Decorator or context-manager with parameters
@overload
def atomic(
    using: str | None = ..., savepoint: bool = ..., durable: bool = ...
) -> Atomic: ...
```