### PR TITLE
Support Deferrable/Read-Only Transactions

### DIFF
--- a/pgtransaction/__init__.py
+++ b/pgtransaction/__init__.py
@@ -1,12 +1,25 @@
-# flake8: noqa
-
-from django.db.transaction import *
-
 from pgtransaction.transaction import (
-    Atomic,
-    atomic,
+    DEFERRABLE,
+    NOT_DEFERRABLE,
     READ_COMMITTED,
+    READ_ONLY,
+    READ_WRITE,
     REPEATABLE_READ,
     SERIALIZABLE,
+    Atomic,
+    atomic,
 )
 from pgtransaction.version import __version__
+
+__all__ = [
+    "Atomic",
+    "atomic",
+    "READ_COMMITTED",
+    "REPEATABLE_READ",
+    "SERIALIZABLE",
+    "READ_WRITE",
+    "READ_ONLY",
+    "DEFERRABLE",
+    "NOT_DEFERRABLE",
+    "__version__",
+]

--- a/pgtransaction/tests/test_transaction.py
+++ b/pgtransaction/tests/test_transaction.py
@@ -307,9 +307,7 @@ def test_concurrent_serialization_error():
 def test_atomic_read_only():
     """Test that a read only transaction cannot write."""
     with atomic(read_mode=pgtransaction.READ_ONLY):
-        trade = ddf.G(Trade)
-        assert trade.id is not None
-
+        trade = ddf.N(Trade)
         # Should not be able to write.
         with pytest.raises(InternalError):
             if trade is not None:

--- a/pgtransaction/tests/test_transaction.py
+++ b/pgtransaction/tests/test_transaction.py
@@ -301,3 +301,66 @@ def test_concurrent_serialization_error():
     # We should have at least had three attempts. It's highly unlikely we would have four,
     # but the possibility exists.
     assert 3 <= len(calls) <= 4
+
+
+@pytest.mark.django_db(transaction=True)
+def test_atomic_read_only():
+    """Test that a read only transaction cannot write."""
+    with atomic(read_mode=pgtransaction.READ_ONLY):
+        trade = ddf.G(Trade)
+        assert trade.id is not None
+
+        # Should not be able to write.
+        with pytest.raises(InternalError):
+            if trade is not None:
+                trade.price = 2
+                trade.save()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_atomic_deferrable_validation():
+    """Test validation of deferrable mode."""
+
+    # Should raise error if not used with SERIALIZABLE and READ ONLY
+    with pytest.raises(ValueError, match="DEFFERABLE transactions have no effect"):
+        with atomic(deferrable=pgtransaction.DEFERRABLE):  # type: ignore - also yields a type error.
+            pass
+
+    # Allowed with SERIALIZABLE and READ ONLY
+    with atomic(
+        isolation_level=pgtransaction.SERIALIZABLE,
+        read_mode=pgtransaction.READ_ONLY,
+        deferrable=pgtransaction.DEFERRABLE,
+    ):
+        pass
+
+
+@pytest.mark.django_db(transaction=True)
+def test_deferrable_read_only_behavior():
+    """Test behavior of deferrable read only transactions."""
+    import threading
+
+    trade = ddf.G(Trade, company="Company 1")
+
+    def modify_data() -> None:
+        with atomic():
+            trade_obj = Trade.objects.get(id=trade.id)
+            trade_obj.company = "Company 2"
+            trade_obj.save()
+
+    thread = threading.Thread(target=modify_data)
+
+    with atomic(
+        isolation_level=pgtransaction.SERIALIZABLE,
+        read_mode=pgtransaction.READ_ONLY,
+        deferrable=pgtransaction.DEFERRABLE,
+    ):
+        initial_read = Trade.objects.get(id=trade.id)
+        assert initial_read.company == "Company 1"
+
+        thread.start()
+        thread.join()
+
+        # Data should stay the same.
+        final_read = Trade.objects.get(id=trade.id)
+        assert final_read.company == "Company 1"

--- a/pgtransaction/tests/test_transaction.py
+++ b/pgtransaction/tests/test_transaction.py
@@ -310,7 +310,7 @@ def test_atomic_read_only():
         trade = ddf.N(Trade)
         # Should not be able to write.
         with pytest.raises(InternalError):
-            if trade is not None:
+            if trade is not None:  # pragma: no branch - we always hit this branch
                 trade.price = 2
                 trade.save()
 

--- a/pgtransaction/transaction.py
+++ b/pgtransaction/transaction.py
@@ -126,10 +126,10 @@ class Atomic(transaction.Atomic):
                 transaction_modes.append(f"ISOLATION LEVEL {self.isolation_level.upper()}")
 
             # Only set non-default values.
-            if self.read_mode and self.read_mode.upper() != READ_WRITE:
+            if self.read_mode:
                 transaction_modes.append(self.read_mode.upper())
 
-            if self.deferrable and self.deferrable.upper() != NOT_DEFERRABLE:
+            if self.deferrable:
                 transaction_modes.append(self.deferrable.upper())
 
             if transaction_modes:
@@ -178,8 +178,8 @@ def atomic(
     isolation_level: Literal["SERIALIZABLE"] = ...,
     retry: int | None = None,
     *,
-    read_mode: Literal["READ ONLY"] = "READ ONLY",
-    deferrable: Literal["DEFERRABLE"] = "DEFERRABLE",
+    read_mode: Literal["READ ONLY"] | None = None,
+    deferrable: Literal["DEFERRABLE"] | None = None,
 ) -> Atomic: ...
 
 
@@ -191,8 +191,8 @@ def atomic(
     isolation_level: Literal["READ COMMITTED", "REPEATABLE READ", "SERIALIZABLE"] | None = None,
     retry: int | None = None,
     *,
-    read_mode: Literal["READ WRITE", "READ ONLY"] = "READ WRITE",
-    deferrable: Literal["NOT DEFERRABLE"] = "NOT DEFERRABLE",
+    read_mode: Literal["READ WRITE", "READ ONLY"] | None = None,
+    deferrable: Literal["DEFERRABLE", "NOT DEFERRABLE"] | None = None,
 ) -> Atomic: ...
 
 
@@ -203,8 +203,8 @@ def atomic(
     isolation_level: Literal["READ COMMITTED", "REPEATABLE READ", "SERIALIZABLE"] | None = None,
     retry: int | None = None,
     *,
-    read_mode: Literal["READ WRITE", "READ ONLY"] = "READ WRITE",
-    deferrable: Literal["DEFERRABLE", "NOT DEFERRABLE"] = "NOT DEFERRABLE",
+    read_mode: Literal["READ WRITE", "READ ONLY"] | None = None,
+    deferrable: Literal["DEFERRABLE", "NOT DEFERRABLE"] | None = None,
 ) -> Atomic | _C:
     """
     Extends `django.db.transaction.atomic` with PostgreSQL functionality.
@@ -238,12 +238,8 @@ def atomic(
             is used in a nested atomic block or when used as a context manager.
         read_mode: The read mode for the transaction. Must be one of
             `pgtransaction.READ_WRITE` or `pgtransaction.READ_ONLY`.
-            Default is `pgtransaction.READ_WRITE` (the PostgreSQL default).
-            READ WRITE allows both reads and writes, while READ ONLY
-            prevents any modifications to the database.
         deferrable: Whether the transaction is deferrable. Must be one of
             `pgtransaction.DEFERRABLE` or `pgtransaction.NOT_DEFERRABLE`.
-            Default is `pgtransaction.NOT_DEFERRABLE` (the PostgreSQL default).
             DEFERRABLE only has effect when used with SERIALIZABLE isolation level
             and READ ONLY mode. In this case, it allows the transaction to be
             deferred until it can be executed without causing serialization

--- a/pgtransaction/transaction.py
+++ b/pgtransaction/transaction.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from functools import cached_property, wraps
-from typing import TYPE_CHECKING, Any, Callable, Final, Literal, TypeVar, overload
+from typing import Any, Callable, Final, Literal, TypeVar, overload
 
 import django
 from django.db import DEFAULT_DB_ALIAS, Error, transaction

--- a/pgtransaction/transaction.py
+++ b/pgtransaction/transaction.py
@@ -253,21 +253,21 @@ def atomic(
     # Copies structure of django.db.transaction.atomic
     if callable(using):
         return Atomic(
-            DEFAULT_DB_ALIAS,
-            savepoint,
-            durable,
-            isolation_level,
-            read_mode,
-            deferrable,
-            retry,
+            using=DEFAULT_DB_ALIAS,
+            savepoint=savepoint,
+            durable=durable,
+            isolation_level=isolation_level,
+            retry=retry,
+            read_mode=read_mode,
+            deferrable=deferrable,
         )(using)
     else:
         return Atomic(
-            using,
-            savepoint,
-            durable,
-            isolation_level,
-            read_mode,
-            deferrable,
-            retry,
+            using=using,
+            savepoint=savepoint,
+            durable=durable,
+            isolation_level=isolation_level,
+            retry=retry,
+            read_mode=read_mode,
+            deferrable=deferrable,
         )

--- a/pgtransaction/transaction.py
+++ b/pgtransaction/transaction.py
@@ -68,6 +68,15 @@ class Atomic(transaction.Atomic):
             ):
                 raise ValueError(f'Invalid deferrable mode "{self.deferrable}"')
 
+            if self.deferrable == DEFERRABLE and not (
+                self.isolation_level == SERIALIZABLE and self.read_mode == READ_ONLY
+            ):
+                raise ValueError(
+                    "DEFFERABLE transactions have no effect unless "
+                    "SERIALIZABLE isolation level and "
+                    "READ ONLY mode are used."
+                )
+
     @cached_property
     def retry(self) -> int:
         """
@@ -286,11 +295,3 @@ def atomic(
             read_mode=read_mode,
             deferrable=deferrable,
         )
-
-
-from django.db import transaction
-
-
-@transaction.atomic
-def test():
-    pass

--- a/pgtransaction/transaction.py
+++ b/pgtransaction/transaction.py
@@ -30,9 +30,9 @@ class Atomic(transaction.Atomic):
         using: str | None,
         savepoint: bool,
         durable: bool,
+        *,
         isolation_level: Literal["READ COMMITTED", "REPEATABLE READ", "SERIALIZABLE"] | None,
         retry: int | None,
-        *,
         read_mode: Literal["READ WRITE", "READ ONLY"] | None,
         deferrable: Literal["DEFERRABLE", "NOT DEFERRABLE"] | None,
     ):
@@ -122,25 +122,6 @@ class Atomic(transaction.Atomic):
 
         return inner  # type: ignore - we only care about accuracy for the outer method
 
-    # `typing_extensions` is supported under `TYPE_CHECKING` even if not installed.
-
-    if TYPE_CHECKING:
-        from typing_extensions import deprecated
-
-        @deprecated(
-            "`execute_set_isolation_level` is deprecated and to be removed. "
-            "Use `execute_set_transaction_modes` instead."
-        )
-        def execute_set_isolation_level(self) -> None: ...
-    else:
-
-        def execute_set_isolation_level(self) -> None:  # pragma: no cover
-            _LOGGER.warning(
-                "`execute_set_isolation_level` is deprecated. "
-                "Use `execute_set_transaction_modes` instead."
-            )
-            self.execute_set_transaction_modes()
-
     def execute_set_transaction_modes(self) -> None:
         with self.connection.cursor() as cursor:
             transaction_modes: list[str] = []
@@ -198,9 +179,9 @@ def atomic(
     using: str | None = None,
     savepoint: bool = True,
     durable: bool = False,
+    *,
     isolation_level: Literal["SERIALIZABLE"] = ...,
     retry: int | None = None,
-    *,
     read_mode: Literal["READ ONLY"] | None = None,
     deferrable: Literal["DEFERRABLE"] | None = None,
 ) -> Atomic: ...
@@ -211,9 +192,9 @@ def atomic(
     using: str | None = None,
     savepoint: bool = True,
     durable: bool = False,
+    *,
     isolation_level: Literal["READ COMMITTED", "REPEATABLE READ", "SERIALIZABLE"] | None = None,
     retry: int | None = None,
-    *,
     read_mode: Literal["READ WRITE", "READ ONLY"] | None = None,
     deferrable: Literal["DEFERRABLE", "NOT DEFERRABLE"] | None = None,
 ) -> Atomic: ...
@@ -223,9 +204,9 @@ def atomic(
     using: str | None | _C = None,
     savepoint: bool = True,
     durable: bool = False,
+    *,
     isolation_level: Literal["READ COMMITTED", "REPEATABLE READ", "SERIALIZABLE"] | None = None,
     retry: int | None = None,
-    *,
     read_mode: Literal["READ WRITE", "READ ONLY"] | None = None,
     deferrable: Literal["DEFERRABLE", "NOT DEFERRABLE"] | None = None,
 ) -> Atomic | _C:

--- a/pgtransaction/transaction.py
+++ b/pgtransaction/transaction.py
@@ -276,7 +276,6 @@ def atomic(
 
             import pgtransaction
 
-            # Use REPEATABLE READ isolation level (defaults to READ WRITE mode)
             with pgtransaction.atomic(isolation_level=pgtransaction.REPEATABLE_READ):
                 # Transaction is now REPEATABLE READ for the duration of the block
                 ...

--- a/pgtransaction/transaction.py
+++ b/pgtransaction/transaction.py
@@ -158,16 +158,31 @@ class Atomic(transaction.Atomic):
 def atomic(using: _C) -> _C: ...
 
 
+# Deferrable only has effect when used with SERIALIZABLE isolation level
+# and READ ONLY mode.
 @overload
 def atomic(
     using: str | None = None,
+    *,
     savepoint: bool = True,
     durable: bool = False,
-    isolation_level: Literal["READ COMMITTED", "REPEATABLE READ", "SERIALIZABLE"] | None = None,
     retry: int | None = None,
+    isolation_level: Literal["SERIALIZABLE"],
+    read_mode: Literal["READ ONLY"] | None = None,
+    deferrable: Literal["DEFERRABLE"] | None = None,
+) -> Atomic: ...
+
+
+@overload
+def atomic(
+    using: str | None = None,
     *,
+    savepoint: bool = True,
+    durable: bool = False,
+    isolation_level: Literal["READ COMMITTED", "REPEATABLE READ"] | None = None,
+    retry: int | None = None,
     read_mode: Literal["READ WRITE", "READ ONLY"] | None = None,
-    deferrable: Literal["DEFERRABLE", "NOT DEFERRABLE"] | None = None,
+    deferrable: Literal["NOT DEFERRABLE"] | None = None,
 ) -> Atomic: ...
 
 
@@ -202,12 +217,6 @@ def atomic(
             as anything but None when using [pgtransaction.atomic][]
             is used as a nested atomic block - in that scenario,
             the isolation level is inherited from the parent transaction.
-        read_mode: The read mode for the transaction. Must be one of
-            `pgtransaction.READ_WRITE` or `pgtransaction.READ_ONLY`.
-        deferrable: Whether the transaction is deferrable. Must be one of
-            `pgtransaction.DEFERRABLE` or `pgtransaction.NOT_DEFERRABLE`.
-            Only has effect when used with SERIALIZABLE isolation level
-            and READ ONLY mode.
         retry: An integer specifying the number of attempts
             we want to retry the entire transaction upon encountering
             the settings-specified psycogp2 exceptions. If passed in as
@@ -216,6 +225,12 @@ def atomic(
             `settings.PGTRANSACTION_RETRY`. Note that it is not possible
             to specify a non-zero value of retry when [pgtransaction.atomic][]
             is used in a nested atomic block or when used as a context manager.
+        read_mode: The read mode for the transaction. Must be one of
+            `pgtransaction.READ_WRITE` or `pgtransaction.READ_ONLY`.
+        deferrable: Whether the transaction is deferrable. Must be one of
+            `pgtransaction.DEFERRABLE` or `pgtransaction.NOT_DEFERRABLE`.
+            Only has effect when used with SERIALIZABLE isolation level
+            and READ ONLY mode.
 
     Example:
         Since [pgtransaction.atomic][] inherits from `django.db.transaction.atomic`, it

--- a/pgtransaction/transaction.py
+++ b/pgtransaction/transaction.py
@@ -163,11 +163,11 @@ def atomic(using: _C) -> _C: ...
 @overload
 def atomic(
     using: str | None = None,
-    *,
     savepoint: bool = True,
     durable: bool = False,
+    isolation_level: Literal["SERIALIZABLE"] = ...,
     retry: int | None = None,
-    isolation_level: Literal["SERIALIZABLE"],
+    *,
     read_mode: Literal["READ ONLY"] | None = None,
     deferrable: Literal["DEFERRABLE"] | None = None,
 ) -> Atomic: ...
@@ -176,11 +176,11 @@ def atomic(
 @overload
 def atomic(
     using: str | None = None,
-    *,
     savepoint: bool = True,
     durable: bool = False,
     isolation_level: Literal["READ COMMITTED", "REPEATABLE READ"] | None = None,
     retry: int | None = None,
+    *,
     read_mode: Literal["READ WRITE", "READ ONLY"] | None = None,
     deferrable: Literal["NOT DEFERRABLE"] | None = None,
 ) -> Atomic: ...
@@ -286,3 +286,11 @@ def atomic(
             read_mode=read_mode,
             deferrable=deferrable,
         )
+
+
+from django.db import transaction
+
+
+@transaction.atomic
+def test():
+    pass

--- a/pgtransaction/transaction.py
+++ b/pgtransaction/transaction.py
@@ -134,7 +134,7 @@ class Atomic(transaction.Atomic):
         def execute_set_isolation_level(self) -> None: ...
     else:
 
-        def execute_set_isolation_level(self) -> None:
+        def execute_set_isolation_level(self) -> None:  # pragma: no cover
             _LOGGER.warning(
                 "`execute_set_isolation_level` is deprecated. "
                 "Use `execute_set_transaction_modes` instead."
@@ -155,7 +155,7 @@ class Atomic(transaction.Atomic):
             if self.deferrable:  # pragma: no branch
                 transaction_modes.append(self.deferrable.upper())
 
-            if transaction_modes:
+            if transaction_modes:  # pragma: no branch
                 cursor.execute(f"SET TRANSACTION {' '.join(transaction_modes)}")
 
     def __enter__(self) -> None:

--- a/pgtransaction/transaction.py
+++ b/pgtransaction/transaction.py
@@ -27,9 +27,10 @@ class Atomic(transaction.Atomic):
         savepoint: bool,
         durable: bool,
         isolation_level: Literal["READ COMMITTED", "REPEATABLE READ", "SERIALIZABLE"] | None,
+        retry: int | None,
+        *,
         read_mode: Literal["READ WRITE", "READ ONLY"] | None,
         deferrable: Literal["DEFERRABLE", "NOT DEFERRABLE"] | None,
-        retry: int | None,
     ):
         if django.VERSION >= (3, 2):
             super().__init__(using, savepoint, durable)


### PR DESCRIPTION
This PR adds support for the remaining [Postgres transactions modes](https://www.postgresql.org/docs/current/sql-set-transaction.html):

- `READ ONLY`
- `NOT DEFERRABLE`

Validation/type overloads are added to ensure that if `NOT DEFERRABLE` is set the transaction is additionally `SERIALIZABLE` and `READ_ONLY`, as otherwise it has no effect. New arguments are key-word only, and `execute_set_isolation_level` is deprecated but not removed - making this fully non-breaking.