### PR TITLE
2.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.0.0 (2025-05-24)
+
+#### Api-Break
+
+* Support deferrable and read-only transactions by [@max-muoto](https://github.com/max-muoto) in [#21](https://github.com/AmbitionEng/django-pgtransaction/pull/21).
+  * Breaking changes:
+    * `execute_set_isolation_level` was removed in favor of `execute_set_transaction_modes`.
+    * All arguments that aren't present in the Django implementation of `transaction.atomic` are now keyword-only.
+
 ## 1.5.3 (2025-05-18)
 
 #### Changes

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,8 +69,13 @@ def do_queries():
 
 By default, retries are only performed when `psycopg.errors.SerializationError` or `psycopg.errors.DeadlockDetected` errors are raised. Configure retried psycopg errors with `settings.PGTRANSACTION_RETRY_EXCEPTIONS`. You can set a default retry amount with `settings.PGTRANSACTION_RETRY`.
 
+### Nested Usage
+
+[pgtransaction.atomic][] can be nested, but keep the following in mind:
+
 1. Isolation mode cannot be changed once a query has been performed.
-2. The retry argument only works on the outermost invocation as a decorator, otherwise `RuntimeError` is raised.
+2. Read-write mode can not be changed to from within a read only block.
+3. The retry argument only works on the outermost invocation as a decorator, otherwise `RuntimeError` is raised.
 
 ## Compatibility
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ See [module docs](module.md) and the quickstart below for examples.
 
 ## Quickstart
 
-After [installation](installation.md), use [pgtransaction.atomic][] to control transaction characteristics:
+After [installation](installation.md), set transaction characteristics using [pgtransaction.atomic][]:
 
 ### Isolation Levels
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,7 +69,7 @@ def do_queries():
 
 By default, retries are only performed when `psycopg.errors.SerializationError` or `psycopg.errors.DeadlockDetected` errors are raised. Configure retried psycopg errors with `settings.PGTRANSACTION_RETRY_EXCEPTIONS`. You can set a default retry amount with `settings.PGTRANSACTION_RETRY`.
 
-1. Transaction characteristics cannot be changed once a query has been performed.
+1. Isolation mode cannot be changed once a query has been performed.
 2. The retry argument only works on the outermost invocation as a decorator, otherwise `RuntimeError` is raised.
 
 ## Compatibility

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,9 +69,7 @@ def do_queries():
 
 By default, retries are only performed when `psycopg.errors.SerializationError` or `psycopg.errors.DeadlockDetected` errors are raised. Configure retried psycopg errors with `settings.PGTRANSACTION_RETRY_EXCEPTIONS`. You can set a default retry amount with `settings.PGTRANSACTION_RETRY`.
 
-[pgtransaction.atomic][] can be nested, but keep the following in mind:
-
-1. The isolation level cannot be changed once a query has been performed.
+1. Transaction characteristics cannot be changed once a query has been performed.
 2. The retry argument only works on the outermost invocation as a decorator, otherwise `RuntimeError` is raised.
 
 ## Compatibility

--- a/pgtransaction/tests/test_transaction.py
+++ b/pgtransaction/tests/test_transaction.py
@@ -127,13 +127,6 @@ def test_atomic_nested_read_modes():
             with atomic(read_mode=pgtransaction.READ_WRITE):
                 pass
 
-    # Same restriction applies even in READ_WRITE transactions
-    with pytest.raises(InternalError):
-        with atomic(read_mode=pgtransaction.READ_WRITE):
-            ddf.G(Trade)
-            with atomic(read_mode=pgtransaction.READ_WRITE):
-                pass
-
 
 @pytest.mark.django_db()
 def test_atomic_with_nested_atomic():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ packages = [
 exclude = [
   "*/tests/"
 ]
-version = "1.5.3"
+version = "2.0.0"
 description = "A context manager/decorator which extends Django's atomic function with the ability to set isolation level and retries for a given transaction."
 authors = ["Paul Gilmartin", "Wes Kendall"]
 classifiers = [


### PR DESCRIPTION
This PR bumps the version to 2.0. In addition, I made some small tweaks to the documentation to better structure the examples. I removed the section around how Postgres defaults are followed, as that's not universally the case if custom defaults are used.